### PR TITLE
Add support for ARM to pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -43,6 +47,7 @@ jobs:
         with:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           file: build/Dockerfile
           tags: |
             infrolabs/infro-core:latest


### PR DESCRIPTION
A lot of people, including me, run their homelab om the ARM cpu architecture instead of x86. It would be great if the docker image that is available for the selfhosted option would be available on ARM.

I've tested this build is currently running on my homelab.