### PR TITLE
Check both SSH and HTTPS repos

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -40,8 +40,12 @@ func NewClient(cfg *Config) *Client {
 	return &Client{cfg}
 }
 
-func (c Client) RepoURL(owner string, repo string) string {
+func (c Client) RepoURLHTTPS(owner string, repo string) string {
 	return fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+}
+
+func (c Client) RepoURLSSH(owner string, repo string) string {
+	return fmt.Sprintf("git@github.com:%s/%s.git", owner, repo)
 }
 
 //nolint:gochecknoglobals // fine for templates

--- a/pkg/infro/executor.go
+++ b/pkg/infro/executor.go
@@ -23,7 +23,8 @@ type (
 		ExecuteDryRuns(context.Context, model.DryRunOpts) ([]model.DryRun, error)
 	}
 	VCSClient interface {
-		RepoURL(owner string, repo string) string
+		RepoURLHTTPS(owner string, repo string) string
+		RepoURLSSH(owner string, repo string) string
 		UpsertComment(context.Context, model.UpsertCommentOpts) (*Comment, error)
 		ListPullRequests(context.Context, model.ListPullRequestsOpts) ([]model.PullRequest, error)
 	}
@@ -70,22 +71,25 @@ func (e *Executor) Comment(ctx context.Context, opts CommentOpts) (*Comment, err
 	ctx = xzap.NewContext(ctx, log)
 
 	var dryRuns []model.DryRun
+	repoURLs := []string{e.vcsClient.RepoURLHTTPS(opts.Owner, opts.Repo), e.vcsClient.RepoURLSSH(opts.Owner, opts.Repo)}
 	for _, depClient := range e.deployerClients {
-		newDryRuns, err := depClient.ExecuteDryRuns(ctx, model.DryRunOpts{
-			Revision: opts.Revision,
-			RepoURL:  e.vcsClient.RepoURL(opts.Owner, opts.Repo),
-		})
-		if err != nil {
-			log.Error("failed to execute dry runs", zap.Error(err))
-		}
-		for _, newDryRun := range newDryRuns {
-			if newDryRun.Diff == nil && newDryRun.Err == nil {
-				log.Info("no diff for deployment",
-					zap.String("deployer", newDryRun.DeployerName),
-					zap.String("deployment", newDryRun.DeploymentName))
-				continue
+		for _, repoURL := range repoURLs {
+			newDryRuns, err := depClient.ExecuteDryRuns(ctx, model.DryRunOpts{
+				Revision: opts.Revision,
+				RepoURL:  repoURL,
+			})
+			if err != nil {
+				log.Error("failed to execute dry runs", zap.Error(err))
 			}
-			dryRuns = append(dryRuns, newDryRun)
+			for _, newDryRun := range newDryRuns {
+				if newDryRun.Diff == nil && newDryRun.Err == nil {
+					log.Info("no diff for deployment",
+						zap.String("deployer", newDryRun.DeployerName),
+						zap.String("deployment", newDryRun.DeploymentName))
+					continue
+				}
+				dryRuns = append(dryRuns, newDryRun)
+			}
 		}
 	}
 	if len(dryRuns) == 0 {

--- a/pkg/infro/executor_test.go
+++ b/pkg/infro/executor_test.go
@@ -28,8 +28,12 @@ func (m *mockVCSClient) UpsertComment(ctx context.Context, opts model.UpsertComm
 	return nil, m.Called(ctx, opts).Error(0)
 }
 
-func (m *mockVCSClient) RepoURL(_, _ string) string {
+func (m *mockVCSClient) RepoURLHTTPS(_, _ string) string {
 	return "http://example.org"
+}
+
+func (m *mockVCSClient) RepoURLSSH(_, _ string) string {
+	return "git@example.org"
 }
 
 func (m *mockVCSClient) ListPullRequests(context.Context, model.ListPullRequestsOpts) ([]model.PullRequest, error) {


### PR DESCRIPTION
Currently only HTTPS repos are checked in ArgoCD, so if you have some repos that are using SSH, it won't display a diff. 
This should make it check for Apps configured for the current repo with both schemes.

Fixes #7